### PR TITLE
Update license, solve todo's, add system classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,22 @@ if (result.ok()) {
 }
 ```
 
+Or
+
+```cpp
+#include "ws/imaging/image.h"
+#include "ws/status/status_or.h"
+
+using namespace ws;
+
+Status ProcessImage(Args) {
+  imaging::Image image;
+  ASSIGN_OR_RETURN(image, imaging::Image::Create(std::move(components), width, height,
+                                     ColorSpace::kRGB, ChromaSubsampling::k444))
+  // Process image...
+}
+```
+
 ## Contributing
 
 1. Fork the repository

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -7,7 +7,7 @@ This repository incorporates material as listed below or described in the code.
 Abseil LTS 20250512.1 - Apache 2.0
 https://github.com/abseil/abseil-cpp
 
-Copyright 2025 The Abseil Authors.
+Copyright (C) 2017-2025 The Abseil Authors.
 
                                  Apache License
                            Version 2.0, January 2004
@@ -216,7 +216,7 @@ Copyright 2025 The Abseil Authors.
 oneTBB 2022.2.0 - Apache 2.0
 https://github.com/uxlfoundation/oneTBB
 
-Copyright 2025 Intel Corporation.
+Copyright (C) 2005–2025 Intel Corporation.
 
                                  Apache License
                            Version 2.0, January 2004

--- a/src/ws/imaging/image.h
+++ b/src/ws/imaging/image.h
@@ -33,10 +33,10 @@ class Image {
   uint8_t NumComponents() const;
   const ImageComponent& GetComponent(uint8_t comp_num) const;
   const Array<ImageComponent>& Components() const;
-  uint32_t Width() const;
-  uint32_t Height() const;
-  ColorSpace GetColorSpace() const;
-  ChromaSubsampling GetChromaSubsampling() const;
+  constexpr uint32_t Width() const;
+  constexpr uint32_t Height() const;
+  constexpr ColorSpace GetColorSpace() const;
+  constexpr ChromaSubsampling GetChromaSubsampling() const;
   bool HasAlpha() const;
   bool Empty() const;
   bool IsValid() const;
@@ -70,13 +70,15 @@ inline const Array<ImageComponent>& Image::Components() const {
   return components_;
 }
 
-inline uint32_t Image::Width() const { return width_; }
+inline constexpr uint32_t Image::Width() const { return width_; }
 
-inline uint32_t Image::Height() const { return height_; }
+inline constexpr uint32_t Image::Height() const { return height_; }
 
-inline ColorSpace Image::GetColorSpace() const { return color_space_; }
+inline constexpr ColorSpace Image::GetColorSpace() const {
+  return color_space_;
+}
 
-inline ChromaSubsampling Image::GetChromaSubsampling() const {
+inline constexpr ChromaSubsampling Image::GetChromaSubsampling() const {
   return chroma_subsampling_;
 }
 

--- a/src/ws/imaging/image_buffer_type.cc
+++ b/src/ws/imaging/image_buffer_type.cc
@@ -2,21 +2,6 @@
 
 namespace ws {
 namespace imaging {
-ImageBufferType DetermineImageBufferType(uint8_t bit_depth) {
-  if (bit_depth >= 2 && bit_depth <= 8) {
-    return ImageBufferType::kUInt8;
-  } else if (bit_depth >= 9 && bit_depth <= 12) {
-    return ImageBufferType::kInt16;
-  } else if (bit_depth >= 13 && bit_depth <= 16) {
-    return ImageBufferType::kUInt16;
-  } else if (bit_depth >= 17 && bit_depth <= 24) {
-    return ImageBufferType::kInt32;
-  } else if (bit_depth >= 25 && bit_depth <= 32) {
-    return ImageBufferType::kUInt32;
-  } else {
-    return ImageBufferType::kUnknown;
-  }
-}
 
 std::string ImageBufferTypeToString(ImageBufferType type) {
   switch (type) {

--- a/src/ws/imaging/image_buffer_type.h
+++ b/src/ws/imaging/image_buffer_type.h
@@ -15,7 +15,21 @@ enum class ImageBufferType : int8_t {
   kUnknown
 };
 
-ImageBufferType DetermineImageBufferType(uint8_t bit_depth);
+constexpr ImageBufferType DetermineImageBufferType(uint8_t bit_depth) {
+  if (bit_depth >= 2 && bit_depth <= 8) {
+    return ImageBufferType::kUInt8;
+  } else if (bit_depth >= 9 && bit_depth <= 12) {
+    return ImageBufferType::kInt16;
+  } else if (bit_depth >= 13 && bit_depth <= 16) {
+    return ImageBufferType::kUInt16;
+  } else if (bit_depth >= 17 && bit_depth <= 24) {
+    return ImageBufferType::kInt32;
+  } else if (bit_depth >= 25 && bit_depth <= 32) {
+    return ImageBufferType::kUInt32;
+  } else {
+    return ImageBufferType::kUnknown;
+  }
+}
 
 std::string ImageBufferTypeToString(ImageBufferType type);
 

--- a/src/ws/imaging/image_component.h
+++ b/src/ws/imaging/image_component.h
@@ -32,15 +32,15 @@ class ImageComponent {
 
   ~ImageComponent();
 
-  uint32_t Width() const;
-  size_t Length() const;
-  size_t Height() const;
-  uint8_t BitDepth() const;
-  bool IsAlpha() const;
-  bool Empty() const;
-  bool IsValid() const;
+  constexpr uint32_t Width() const;
+  constexpr size_t Length() const;
+  constexpr size_t Height() const;
+  constexpr uint8_t BitDepth() const;
+  constexpr bool IsAlpha() const;
+  constexpr bool Empty() const;
+  constexpr bool IsValid() const;
   std::string ToString() const;
-  ImageBufferType GetBufferType() const;
+  constexpr ImageBufferType GetBufferType() const;
   template <ws::imaging::IsAllowedPixelNumericType T>
   T* Buffer() const;
 
@@ -64,24 +64,26 @@ class ImageComponent {
 // Implementation details for ImageComponent
 // ============================================================================
 
-inline uint32_t ImageComponent::Width() const { return width_; }
+inline constexpr uint32_t ImageComponent::Width() const { return width_; }
 
-inline size_t ImageComponent::Length() const { return length_; }
+inline constexpr size_t ImageComponent::Length() const { return length_; }
 
-inline size_t ImageComponent::Height() const { return height_; }
+inline constexpr size_t ImageComponent::Height() const { return height_; }
 
-inline uint8_t ImageComponent::BitDepth() const { return bit_depth_; }
+inline constexpr uint8_t ImageComponent::BitDepth() const { return bit_depth_; }
 
-inline bool ImageComponent::IsAlpha() const { return is_alpha_; }
+inline constexpr bool ImageComponent::IsAlpha() const { return is_alpha_; }
 
-inline bool ImageComponent::Empty() const { return buffer_ == nullptr; }
+inline constexpr bool ImageComponent::Empty() const {
+  return buffer_ == nullptr;
+}
 
-inline bool ImageComponent::IsValid() const {
+inline constexpr bool ImageComponent::IsValid() const {
   return !Empty() && length_ != 0 && width_ != 0 && bit_depth_ != 0 &&
          buffer_type_ != ImageBufferType::kUnknown;
 }
 
-inline ImageBufferType ImageComponent::GetBufferType() const {
+inline constexpr ImageBufferType ImageComponent::GetBufferType() const {
   return buffer_type_;
 }
 

--- a/src/ws/imaging/image_converter.h
+++ b/src/ws/imaging/image_converter.h
@@ -18,9 +18,9 @@ class ImageConverter {
 
   virtual ~ImageConverter() = default;
 
-  uint8_t NumComponents() const;
-  ColorSpace GetColorSpace() const;
-  ChromaSubsampling GetChromaSubsampling() const;
+  constexpr uint8_t NumComponents() const;
+  constexpr ColorSpace GetColorSpace() const;
+  constexpr ChromaSubsampling GetChromaSubsampling() const;
   void SetLogger(std::unique_ptr<ws::logging::ILogger>&& logger);
   virtual StatusOr<Image> Convert(const Image& source) const = 0;
 
@@ -53,11 +53,16 @@ class TypedImageConverter : public ImageConverter {
 // ============================================================================
 // Implementation details for ImageConverter
 // ============================================================================
-inline uint8_t ImageConverter::NumComponents() const { return num_components_; }
+inline constexpr uint8_t ImageConverter::NumComponents() const {
+  return num_components_;
+}
 
-inline ColorSpace ImageConverter::GetColorSpace() const { return color_space_; }
+inline constexpr ColorSpace ImageConverter::GetColorSpace() const {
+  return color_space_;
+}
 
-inline ChromaSubsampling ImageConverter::GetChromaSubsampling() const {
+inline constexpr ChromaSubsampling ImageConverter::GetChromaSubsampling()
+    const {
   return chroma_subsampling_;
 }
 

--- a/src/ws/imaging/pixel/color_formats/srgb/srgb_to_gray_converter.cc
+++ b/src/ws/imaging/pixel/color_formats/srgb/srgb_to_gray_converter.cc
@@ -3,9 +3,10 @@
 namespace ws {
 namespace imaging {
 template <IsAllowedPixelNumericType T>
-SRgbToGrayConverter<T>::SRgbToGrayConverter(uint8_t bit_depth)
+SRgbToGrayConverter<T>::SRgbToGrayConverter(
+    uint8_t bit_depth, PixelColorConverter<T>::DigitalTvStudioEncodingRec rec)
     : PixelColorConverter<T>(bit_depth),
-      coeffs_(PixelColorConverter<T>::BT2020Coefficients) {}
+      coeffs_(PixelColorConverter<T>::GetEncodingCoefficients(rec)) {}
 
 template <IsAllowedPixelNumericType T>
 void SRgbToGrayConverter<T>::Convert(const Rgb<T>& rgb, Gray<T>& gray) const {
@@ -20,7 +21,6 @@ void SRgbToGrayConverter<T>::ConvertWithAlpha(const Rgba<T>& rgba,
   ya.gray = gray.gray;
   ya.alpha = rgba.alpha;
 }
-// TODO: ADD ENUM FOR MethodSUPPORT
 
 template class SRgbToGrayConverter<uint8_t>;
 template class SRgbToGrayConverter<int8_t>;

--- a/src/ws/imaging/pixel/color_formats/srgb/srgb_to_gray_converter.h
+++ b/src/ws/imaging/pixel/color_formats/srgb/srgb_to_gray_converter.h
@@ -9,7 +9,10 @@ namespace imaging {
 template <IsAllowedPixelNumericType T>
 class SRgbToGrayConverter : public PixelColorConverter<T> {
  public:
-  explicit SRgbToGrayConverter(uint8_t bit_depth);
+  explicit SRgbToGrayConverter(
+      uint8_t bit_depth,
+      PixelColorConverter<T>::DigitalTvStudioEncodingRec rec =
+          PixelColorConverter<T>::DigitalTvStudioEncodingRec::kBT2020);
 
   void Convert(const Rgb<T>& rgb, Gray<T>& gray) const;
   void ConvertWithAlpha(const Rgba<T>& rgba, Ya<T>& ya) const;

--- a/src/ws/imaging/pixel/color_formats/srgb/srgb_to_sycc_converter.cc
+++ b/src/ws/imaging/pixel/color_formats/srgb/srgb_to_sycc_converter.cc
@@ -3,9 +3,10 @@
 namespace ws {
 namespace imaging {
 template <IsAllowedPixelNumericType T>
-SRgbToSYccConverter<T>::SRgbToSYccConverter(uint8_t bit_depth)
+SRgbToSYccConverter<T>::SRgbToSYccConverter(
+    uint8_t bit_depth, PixelColorConverter<T>::DigitalTvStudioEncodingRec rec)
     : PixelColorConverter<T>(bit_depth),
-      coeffs_(PixelColorConverter<T>::BT2020Coefficients) {}
+      coeffs_(PixelColorConverter<T>::GetEncodingCoefficients(rec)) {}
 
 template <IsAllowedPixelNumericType T>
 void SRgbToSYccConverter<T>::Convert(const Rgb<T>& rgb, Ycc<T>& ycc) const {
@@ -21,7 +22,6 @@ void SRgbToSYccConverter<T>::Convert(const Rgb<T>& rgb, Ycc<T>& ycc) const {
   ycc.cb = this->max_value_ * cb;
   ycc.cr = this->max_value_ * cr;
 }
-// TODO: ADD ENUM FOR MethodSUPPORT
 
 template class SRgbToSYccConverter<uint8_t>;
 template class SRgbToSYccConverter<int8_t>;

--- a/src/ws/imaging/pixel/color_formats/srgb/srgb_to_sycc_converter.h
+++ b/src/ws/imaging/pixel/color_formats/srgb/srgb_to_sycc_converter.h
@@ -9,7 +9,10 @@ namespace imaging {
 template <IsAllowedPixelNumericType T>
 class SRgbToSYccConverter : public PixelColorConverter<T> {
  public:
-  explicit SRgbToSYccConverter(uint8_t bit_depth);
+  explicit SRgbToSYccConverter(
+      uint8_t bit_depth,
+      PixelColorConverter<T>::DigitalTvStudioEncodingRec rec =
+          PixelColorConverter<T>::DigitalTvStudioEncodingRec::kBT2020);
 
   void Convert(const Rgb<T>& rgb, Ycc<T>& ycc) const;
 

--- a/src/ws/imaging/pixel/color_formats/sycc/sycc_to_srgb_converter.cc
+++ b/src/ws/imaging/pixel/color_formats/sycc/sycc_to_srgb_converter.cc
@@ -3,10 +3,10 @@ namespace ws {
 namespace imaging {
 
 template <IsAllowedPixelNumericType T>
-SYccToRgbConverter<T>::SYccToRgbConverter(uint8_t bit_depth)
-    : PixelColorConverter<T>(bit_depth) {
-  coeffs_ = PixelColorConverter<T>::BT2020Coefficients;
-}
+SYccToRgbConverter<T>::SYccToRgbConverter(
+    uint8_t bit_depth, PixelColorConverter<T>::DigitalTvStudioEncodingRec rec)
+    : PixelColorConverter<T>(bit_depth),
+      coeffs_(PixelColorConverter<T>::GetEncodingCoefficients(rec)) {}
 
 template <IsAllowedPixelNumericType T>
 void SYccToRgbConverter<T>::Convert(const Ycc<T>& ycc, Rgb<T>& rgb) const {
@@ -22,7 +22,6 @@ void SYccToRgbConverter<T>::Convert(const Ycc<T>& ycc, Rgb<T>& rgb) const {
   rgb.g = static_cast<T>(g * this->max_value_);
   rgb.b = static_cast<T>(b * this->max_value_);
 }
-// TODO: ADD ENUM FOR MethodSUPPORT
 
 template class SYccToRgbConverter<uint8_t>;
 template class SYccToRgbConverter<int8_t>;

--- a/src/ws/imaging/pixel/color_formats/sycc/sycc_to_srgb_converter.h
+++ b/src/ws/imaging/pixel/color_formats/sycc/sycc_to_srgb_converter.h
@@ -9,7 +9,10 @@ namespace imaging {
 template <IsAllowedPixelNumericType T>
 class SYccToRgbConverter : public PixelColorConverter<T> {
  public:
-  explicit SYccToRgbConverter(uint8_t bit_depth);
+  explicit SYccToRgbConverter(
+      uint8_t bit_depth,
+      PixelColorConverter<T>::DigitalTvStudioEncodingRec rec =
+          PixelColorConverter<T>::DigitalTvStudioEncodingRec::kBT2020);
 
   void Convert(const Ycc<T>& ycc, Rgb<T>& rgb) const;
 

--- a/src/ws/imaging/pixel/pixel_color_converter.h
+++ b/src/ws/imaging/pixel/pixel_color_converter.h
@@ -19,7 +19,12 @@ class PixelColorConverter {
  public:
   virtual ~PixelColorConverter() = default;
 
+  enum class DigitalTvStudioEncodingRec { kBT601, kBT709, kBT2020, kBT2100 };
+
  protected:
+  static constexpr Rgb<double> GetEncodingCoefficients(
+      DigitalTvStudioEncodingRec rec);
+
   // BT.601 (SD)
   static constexpr Rgb<double> BT601Coefficients = {0.299, 0.587, 0.114};
   // BT.709 (HD)
@@ -34,5 +39,22 @@ class PixelColorConverter {
   T min_value_;
   T max_value_;
 };
+
+template <IsAllowedPixelNumericType T>
+inline constexpr Rgb<double> PixelColorConverter<T>::GetEncodingCoefficients(
+    DigitalTvStudioEncodingRec rec) {
+  switch (rec) {
+    case DigitalTvStudioEncodingRec::kBT601:
+      return BT601Coefficients;
+    case DigitalTvStudioEncodingRec::kBT709:
+      return BT709Coefficients;
+    case DigitalTvStudioEncodingRec::kBT2100:
+      return BT2100Coefficients;
+    case DigitalTvStudioEncodingRec::kBT2020:
+    default:
+      return BT2020Coefficients;
+  }
+}
+
 }  // namespace imaging
 }  // namespace ws

--- a/src/ws/imaging/pixel/pixel_format_details.h
+++ b/src/ws/imaging/pixel/pixel_format_details.h
@@ -20,13 +20,15 @@ struct PixelFormatDetails {
   PixelLayoutFlag layout;
   bool has_common_order;
 
-  bool HasAlpha() const;
+  constexpr bool HasAlpha() const;
 };
 
 // ============================================================================
 // Implementation details for PixelFormatDetails
 // ============================================================================
 
-inline bool PixelFormatDetails::HasAlpha() const { return alpha_index != -1; }
+inline constexpr bool PixelFormatDetails::HasAlpha() const {
+  return alpha_index != -1;
+}
 }  // namespace imaging
 }  // namespace ws

--- a/src/ws/io/CMakeLists.txt
+++ b/src/ws/io/CMakeLists.txt
@@ -3,6 +3,7 @@ wscommon_cc_library(
     io
   SRCS
     buffer_stream.cc
+    directory.cc
     file_handle.cc
     file_stream.cc
     file.cc
@@ -11,6 +12,7 @@ wscommon_cc_library(
     stream.cc
   HDRS
     buffer_stream.h
+    directory.h
     file_access.h
     file_format.h
     file_format_detector.h

--- a/src/ws/io/CMakeLists.txt
+++ b/src/ws/io/CMakeLists.txt
@@ -7,6 +7,7 @@ wscommon_cc_library(
     file_stream.cc
     file.cc
     memory_stream.cc
+    path.cc
     stream.cc
   HDRS
     buffer_stream.h
@@ -19,6 +20,7 @@ wscommon_cc_library(
     file_stream.h
     file.h
     memory_stream.h
+    path.h
     seek_origin.h
     stream.h
   DEPS

--- a/src/ws/io/directory.cc
+++ b/src/ws/io/directory.cc
@@ -11,29 +11,27 @@ StatusOr<std::vector<std::string>> Directory::GetFiles(
   std::string searchPath = Path::NormalizePath(path) + "*";
   WIN32_FIND_DATAA findData;
   HANDLE hFind = FindFirstFileA(searchPath.c_str(), &findData);
-
   if (hFind == INVALID_HANDLE_VALUE) {
     DWORD error = GetLastError();
-    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND)
       return Status(StatusCode::kNotFound, "Directory not found: " + path);
-    }
+
     return Status(StatusCode::kInternalError,
                   "Failed to open directory: " + GetLastErrorMessage());
   }
 
   do {
-    if (!(findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+    if (!(findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
       files.push_back(std::string(findData.cFileName));
-    }
   } while (FindNextFileA(hFind, &findData));
 
   FindClose(hFind);
 #else
   DIR* dir = opendir(path.c_str());
   if (!dir) {
-    if (errno == ENOENT) {
+    if (errno == ENOENT)
       return Status(StatusCode::kNotFound, "Directory not found: " + path);
-    }
+
     return Status(StatusCode::kInternalError,
                   "Failed to open directory: " + GetLastErrorMessage());
   }
@@ -50,7 +48,6 @@ StatusOr<std::vector<std::string>> Directory::GetFiles(
 
   closedir(dir);
 #endif
-
   std::sort(files.begin(), files.end());
   return files;
 }
@@ -58,17 +55,15 @@ StatusOr<std::vector<std::string>> Directory::GetFiles(
 StatusOr<std::vector<std::string>> Directory::GetDirectories(
     const std::string& path) {
   std::vector<std::string> directories;
-
 #ifdef _WIN32
   std::string searchPath = Path::NormalizePath(path) + "*";
   WIN32_FIND_DATAA findData;
   HANDLE hFind = FindFirstFileA(searchPath.c_str(), &findData);
-
   if (hFind == INVALID_HANDLE_VALUE) {
     DWORD error = GetLastError();
-    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND)
       return Status(StatusCode::kNotFound, "Directory not found: " + path);
-    }
+
     return Status(StatusCode::kInternalError,
                   "Failed to open directory: " + GetLastErrorMessage());
   }
@@ -85,18 +80,17 @@ StatusOr<std::vector<std::string>> Directory::GetDirectories(
 #else
   DIR* dir = opendir(path.c_str());
   if (!dir) {
-    if (errno == ENOENT) {
+    if (errno == ENOENT)
       return Status(StatusCode::kNotFound, "Directory not found: " + path);
-    }
+
     return Status(StatusCode::kInternalError,
                   "Failed to open directory: " + GetLastErrorMessage());
   }
 
   struct dirent* entry;
   while ((entry = readdir(dir)) != nullptr) {
-    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
       continue;
-    }
 
     if (entry->d_type == DT_DIR ||
         (entry->d_type == DT_UNKNOWN &&
@@ -108,7 +102,6 @@ StatusOr<std::vector<std::string>> Directory::GetDirectories(
 
   closedir(dir);
 #endif
-
   std::sort(directories.begin(), directories.end());
   return directories;
 }
@@ -124,103 +117,84 @@ Status Directory::Create(const std::string& path) {
     if (error == ERROR_ALREADY_EXISTS) {
       bool is_directory;
       ASSIGN_OR_RETURN(is_directory, Path::IsDirectory(path));
-      if (is_directory) {
-        return Status();
-      }
-
+      if (is_directory) return Status();
       return Status(StatusCode::kConflict,
                     "Path exists but is not a directory: " + path);
     }
-    if (error == ERROR_PATH_NOT_FOUND) {
+
+    if (error == ERROR_PATH_NOT_FOUND)
       return Status(StatusCode::kNotFound,
                     "Parent directory not found: " + path);
-    }
+
     return Status(StatusCode::kInternalError,
                   "Failed to create directory: " + GetLastErrorMessage());
   }
 #else
   if (mkdir(path.c_str(), kDefaultPermissions) != 0) {
     if (errno == EEXIST) {
-      if (Path::IsDirectory(path).ValueOr(false)) {
-        return Status();
-      }
+      if (Path::IsDirectory(path).ValueOr(false)) return Status();
       return Status(StatusCode::kConflict,
                     "Path exists but is not a directory: " + path);
     }
-    if (errno == ENOENT) {
+
+    if (errno == ENOENT)
       return Status(StatusCode::kNotFound,
                     "Parent directory not found: " + path);
-    }
+
     return Status(StatusCode::kInternalError,
                   "Failed to create directory: " + GetLastErrorMessage());
   }
 #endif
-
   return Status();
 }
 
 Status Directory::Delete(const std::string& path, bool recursive) {
-  auto existsResult = Exists(path);
-  if (!existsResult.Ok()) {
-    return existsResult.GetStatus();
-  }
-  if (!existsResult.Value()) {
+  bool exists;
+  ASSIGN_OR_RETURN(exists, Exists(path));
+  if (!exists)
     return Status(StatusCode::kNotFound, "Directory not found: " + path);
-  }
 
   if (recursive) {
-    auto filesResult = GetFiles(path);
-    if (!filesResult.Ok()) {
-      return filesResult.GetStatus();
-    }
-
-    auto dirsResult = GetDirectories(path);
-    if (!dirsResult.Ok()) {
-      return dirsResult.GetStatus();
-    }
-
-    for (const auto& file : filesResult.Value()) {
+    std::vector<std::string> files;
+    std::vector<std::string> directories;
+    ASSIGN_OR_RETURN(files, GetFiles(path));
+    ASSIGN_OR_RETURN(directories, GetDirectories(path));
+    for (const auto& file : files) {
       std::string filePath = Path::NormalizePath(path) + file;
 #ifdef _WIN32
-      if (!DeleteFileA(filePath.c_str())) {
+      if (!DeleteFileA(filePath.c_str()))
         return Status(StatusCode::kInternalError,
                       "Failed to delete file: " + filePath + " - " +
                           GetLastErrorMessage());
-      }
 #else
-      if (unlink(filePath.c_str()) != 0) {
+      if (unlink(filePath.c_str()) != 0)
         return Status(StatusCode::kInternalError,
                       "Failed to delete file: " + filePath + " - " +
                           GetLastErrorMessage());
-      }
 #endif
     }
 
-    for (const auto& dir : dirsResult.Value()) {
+    for (const auto& dir : directories) {
       std::string dirPath = Path::NormalizePath(path) + dir;
-      auto deleteResult = Delete(dirPath, true);
-      if (!deleteResult.Ok()) {
-        return deleteResult;
-      }
+      RETURN_IF_ERROR(Delete(dirPath, true));
     }
   }
 
 #ifdef _WIN32
   if (!RemoveDirectoryA(path.c_str())) {
     DWORD error = GetLastError();
-    if (error == ERROR_DIR_NOT_EMPTY) {
+    if (error == ERROR_DIR_NOT_EMPTY)
       return Status(StatusCode::kFailedDependency,
                     "Directory not empty (use recursive=true): " + path);
-    }
+
     return Status(StatusCode::kInternalError,
                   "Failed to delete directory: " + GetLastErrorMessage());
   }
 #else
   if (rmdir(path.c_str()) != 0) {
-    if (errno == ENOTEMPTY) {
+    if (errno == ENOTEMPTY)
       return Status(StatusCode::kFailedDependency,
                     "Directory not empty (use recursive=true): " + path);
-    }
 
     return Status(StatusCode::kInternalError,
                   "Failed to delete directory: " + GetLastErrorMessage());

--- a/src/ws/io/directory.cc
+++ b/src/ws/io/directory.cc
@@ -1,0 +1,307 @@
+#include "ws/io/directory.h"
+
+namespace ws {
+namespace io {
+
+namespace {
+#ifdef _WIN32
+
+bool IsDirectory(const std::string& path) {
+  DWORD attrs = GetFileAttributesA(path.c_str());
+  return (attrs != INVALID_FILE_ATTRIBUTES) &&
+         (attrs & FILE_ATTRIBUTE_DIRECTORY);
+}
+
+bool IsRegularFile(const std::string& path) {
+  DWORD attrs = GetFileAttributesA(path.c_str());
+  return (attrs != INVALID_FILE_ATTRIBUTES) &&
+         !(attrs & FILE_ATTRIBUTE_DIRECTORY);
+}
+#else
+
+bool IsDirectory(const std::string& path) {
+  struct stat statbuf;
+  if (stat(path.c_str(), &statbuf) != 0) {
+    return false;
+  }
+  return S_ISDIR(statbuf.st_mode);
+}
+
+bool IsRegularFile(const std::string& path) {
+  struct stat statbuf;
+  if (stat(path.c_str(), &statbuf) != 0) {
+    return false;
+  }
+  return S_ISREG(statbuf.st_mode);
+}
+#endif
+
+std::string NormalizePath(const std::string& path) {
+  std::string normalized = path;
+  if (!normalized.empty() && normalized.back() != '/' &&
+      normalized.back() != '\\') {
+#ifdef _WIN32
+    normalized += "\\";
+#else
+    normalized += "/";
+#endif
+  }
+  return normalized;
+}
+}  // namespace
+
+StatusOr<std::vector<std::string>> Directory::GetFiles(
+    const std::string& path) {
+  std::vector<std::string> files;
+
+#ifdef _WIN32
+  std::string searchPath = NormalizePath(path) + "*";
+  WIN32_FIND_DATAA findData;
+  HANDLE hFind = FindFirstFileA(searchPath.c_str(), &findData);
+
+  if (hFind == INVALID_HANDLE_VALUE) {
+    DWORD error = GetLastError();
+    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+      return Status(StatusCode::kNotFound, "Directory not found: " + path);
+    }
+    return Status(StatusCode::kInternalError,
+                  "Failed to open directory: " + GetLastErrorMessage());
+  }
+
+  do {
+    if (!(findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+      files.push_back(std::string(findData.cFileName));
+    }
+  } while (FindNextFileA(hFind, &findData));
+
+  FindClose(hFind);
+#else
+  DIR* dir = opendir(path.c_str());
+  if (!dir) {
+    if (errno == ENOENT) {
+      return Status(StatusCode::kNotFound, "Directory not found: " + path);
+    }
+    return Status(StatusCode::kInternalError,
+                  "Failed to open directory: " + GetLastErrorMessage());
+  }
+
+  struct dirent* entry;
+  while ((entry = readdir(dir)) != nullptr) {
+    if (entry->d_type == DT_REG ||
+        (entry->d_type == DT_UNKNOWN &&
+         IsRegularFile(NormalizePath(path) + entry->d_name))) {
+      files.push_back(std::string(entry->d_name));
+    }
+  }
+
+  closedir(dir);
+#endif
+
+  std::sort(files.begin(), files.end());
+  return files;
+}
+
+StatusOr<std::vector<std::string>> Directory::GetDirectories(
+    const std::string& path) {
+  std::vector<std::string> directories;
+
+#ifdef _WIN32
+  std::string searchPath = NormalizePath(path) + "*";
+  WIN32_FIND_DATAA findData;
+  HANDLE hFind = FindFirstFileA(searchPath.c_str(), &findData);
+
+  if (hFind == INVALID_HANDLE_VALUE) {
+    DWORD error = GetLastError();
+    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+      return Status(StatusCode::kNotFound, "Directory not found: " + path);
+    }
+    return Status(StatusCode::kInternalError,
+                  "Failed to open directory: " + GetLastErrorMessage());
+  }
+
+  do {
+    if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
+        strcmp(findData.cFileName, ".") != 0 &&
+        strcmp(findData.cFileName, "..") != 0) {
+      directories.push_back(std::string(findData.cFileName));
+    }
+  } while (FindNextFileA(hFind, &findData));
+
+  FindClose(hFind);
+#else
+  DIR* dir = opendir(path.c_str());
+  if (!dir) {
+    if (errno == ENOENT) {
+      return Status(StatusCode::kNotFound, "Directory not found: " + path);
+    }
+    return Status(StatusCode::kInternalError,
+                  "Failed to open directory: " + GetLastErrorMessage());
+  }
+
+  struct dirent* entry;
+  while ((entry = readdir(dir)) != nullptr) {
+    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+      continue;
+    }
+
+    if (entry->d_type == DT_DIR ||
+        (entry->d_type == DT_UNKNOWN &&
+         IsDirectory(NormalizePath(path) + entry->d_name))) {
+      directories.push_back(std::string(entry->d_name));
+    }
+  }
+
+  closedir(dir);
+#endif
+
+  std::sort(directories.begin(), directories.end());
+  return directories;
+}
+
+StatusOr<bool> Directory::Exists(const std::string& path) {
+#ifdef _WIN32
+  DWORD attrs = GetFileAttributesA(path.c_str());
+  if (attrs == INVALID_FILE_ATTRIBUTES) {
+    DWORD error = GetLastError();
+    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+      return false;
+    }
+    return Status(
+        StatusCode::kInternalError,
+        "Failed to check directory existence: " + GetLastErrorMessage());
+  }
+  return (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0;
+#else
+  struct stat statbuf;
+  if (stat(path.c_str(), &statbuf) != 0) {
+    if (errno == ENOENT) {
+      return false;
+    }
+    return Status(
+        StatusCode::kInternalError,
+        "Failed to check directory existence: " + GetLastErrorMessage());
+  }
+  return S_ISDIR(statbuf.st_mode);
+#endif
+}
+
+StatusOr<void> Directory::Create(const std::string& path) {
+#ifdef _WIN32
+  if (!CreateDirectoryA(path.c_str(), nullptr)) {
+    DWORD error = GetLastError();
+    if (error == ERROR_ALREADY_EXISTS) {
+      // Check if it's actually a directory
+      if (IsDirectory(path)) {
+        return Status();  // Success - directory already exists
+      }
+      return Status(StatusCode::kConflict,
+                    "Path exists but is not a directory: " + path);
+    }
+    if (error == ERROR_PATH_NOT_FOUND) {
+      return Status(StatusCode::kNotFound,
+                    "Parent directory not found: " + path);
+    }
+    return Status(StatusCode::kInternalError,
+                  "Failed to create directory: " + GetLastErrorMessage());
+  }
+#else
+  if (mkdir(path.c_str(), kDefaultPermissions) != 0) {
+    if (errno == EEXIST) {
+      // Check if it's actually a directory
+      if (IsDirectory(path)) {
+        return Status();  // Success - directory already exists
+      }
+      return Status(StatusCode::kConflict,
+                    "Path exists but is not a directory: " + path);
+    }
+    if (errno == ENOENT) {
+      return Status(StatusCode::kNotFound,
+                    "Parent directory not found: " + path);
+    }
+    return Status(StatusCode::kInternalError,
+                  "Failed to create directory: " + GetLastErrorMessage());
+  }
+#endif
+
+  return Status();  // Success
+}
+
+StatusOr<void> Directory::Delete(const std::string& path, bool recursive) {
+  // First check if directory exists
+  auto existsResult = Exists(path);
+  if (!existsResult.Ok()) {
+    return existsResult.GetStatus();
+  }
+  if (!existsResult.Value()) {
+    return Status(StatusCode::kNotFound, "Directory not found: " + path);
+  }
+
+  if (recursive) {
+    // Get all files and directories first
+    auto filesResult = GetFiles(path);
+    if (!filesResult.Ok()) {
+      return filesResult.GetStatus();
+    }
+
+    auto dirsResult = GetDirectories(path);
+    if (!dirsResult.Ok()) {
+      return dirsResult.GetStatus();
+    }
+
+    // Delete all files
+    for (const auto& file : filesResult.Value()) {
+      std::string filePath = NormalizePath(path) + file;
+#ifdef _WIN32
+      if (!DeleteFileA(filePath.c_str())) {
+        return Status(StatusCode::kInternalError,
+                      "Failed to delete file: " + filePath + " - " +
+                          GetLastErrorMessage());
+      }
+#else
+      if (unlink(filePath.c_str()) != 0) {
+        return Status(StatusCode::kInternalError,
+                      "Failed to delete file: " + filePath + " - " +
+                          GetLastErrorMessage());
+      }
+#endif
+    }
+
+    // Recursively delete all subdirectories
+    for (const auto& dir : dirsResult.Value()) {
+      std::string dirPath = NormalizePath(path) + dir;
+      auto deleteResult = Delete(dirPath, true);
+      if (!deleteResult.Ok()) {
+        return deleteResult;
+      }
+    }
+  }
+
+  // Finally delete the directory itself
+#ifdef _WIN32
+  if (!RemoveDirectoryA(path.c_str())) {
+    DWORD error = GetLastError();
+    if (error == ERROR_DIR_NOT_EMPTY) {
+      return Status(StatusCode::kFailedDependency,
+                    "Directory not empty (use recursive=true): " + path);
+    }
+    return Status(StatusCode::kInternalError,
+                  "Failed to delete directory: " + GetLastErrorMessage());
+  }
+#else
+  if (rmdir(path.c_str()) != 0) {
+    if (errno == ENOTEMPTY) {
+      return Status(StatusCode::kFailedDependency,
+                    "Directory not empty (use recursive=true): " + path);
+    }
+    return Status(StatusCode::kInternalError,
+                  "Failed to delete directory: " + GetLastErrorMessage());
+  }
+#endif
+
+  return Status();
+}
+
+}  // namespace io
+}  // namespace ws
+
+// FIXME: TEST LINUX IMPLEMENTATION

--- a/src/ws/io/directory.cc
+++ b/src/ws/io/directory.cc
@@ -206,5 +206,3 @@ Status Directory::Delete(const std::string& path, bool recursive) {
 
 }  // namespace io
 }  // namespace ws
-
-// FIXME: TEST LINUX IMPLEMENTATION

--- a/src/ws/io/directory.h
+++ b/src/ws/io/directory.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <vector>
 

--- a/src/ws/io/directory.h
+++ b/src/ws/io/directory.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <algorithm>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "ws/machine.h"
+#include "ws/status/status_or.h"
+
+namespace ws {
+namespace io {
+
+class Directory {
+ public:
+  static StatusOr<std::vector<std::string>> GetFiles(const std::string& path);
+  static StatusOr<std::vector<std::string>> GetDirectories(
+      const std::string& path);
+  static StatusOr<bool> Exists(const std::string& path);
+  static StatusOr<void> Create(const std::string& path);
+  static StatusOr<void> Delete(const std::string& path, bool recursive = false);
+
+ private:
+  static bool IsDirectory(const std::string& path);
+
+  static bool IsRegularFile(const std::string& path);
+
+  static constexpr int kDefaultPermissions = 0755;
+};
+}  // namespace io
+}  // namespace ws

--- a/src/ws/io/directory.h
+++ b/src/ws/io/directory.h
@@ -1,11 +1,9 @@
 #pragma once
 
-#include <algorithm>
-#include <filesystem>
 #include <string>
 #include <vector>
 
-#include "ws/machine.h"
+#include "ws/io/path.h"
 #include "ws/status/status_or.h"
 
 namespace ws {
@@ -17,14 +15,10 @@ class Directory {
   static StatusOr<std::vector<std::string>> GetDirectories(
       const std::string& path);
   static StatusOr<bool> Exists(const std::string& path);
-  static StatusOr<void> Create(const std::string& path);
-  static StatusOr<void> Delete(const std::string& path, bool recursive = false);
+  static Status Create(const std::string& path);
+  static Status Delete(const std::string& path, bool recursive = false);
 
  private:
-  static bool IsDirectory(const std::string& path);
-
-  static bool IsRegularFile(const std::string& path);
-
   static constexpr int kDefaultPermissions = 0755;
 };
 }  // namespace io

--- a/src/ws/io/file.cc
+++ b/src/ws/io/file.cc
@@ -29,6 +29,140 @@ StatusOr<FileStream> File::Open(const std::string& path, FileMode mode,
   return FileStream::Create(path, mode, access, share);
 }
 
+StatusOr<bool> File::Exists(const std::string& path) {
+  if (path.empty())
+    return Status(StatusCode::kBadRequest, "Path cannot be empty");
+
+#ifdef _WIN32
+  DWORD attrs = GetFileAttributesA(path.c_str());
+  if (attrs == INVALID_FILE_ATTRIBUTES) {
+    DWORD error = GetLastError();
+    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND)
+      return false;
+
+    return Status(StatusCode::kInternalError,
+                  "Failed to check file existence: " + GetLastErrorMessage());
+  }
+
+  return (attrs & FILE_ATTRIBUTE_DIRECTORY) == 0;
+#else
+  struct stat statbuf;
+  if (stat(path.c_str(), &statbuf) != 0) {
+    if (errno == ENOENT) return false;
+    return Status(StatusCode::kInternalError,
+                  "Failed to check file existence: " + GetLastErrorMessage());
+  }
+
+  return S_ISREG(statbuf.st_mode);
+#endif
+}
+
+Status File::Move(const std::string& sourcePath,
+                  const std::string& destinationPath) {
+  if (sourcePath.empty())
+    return Status(StatusCode::kBadRequest, "Source path cannot be empty");
+
+  if (destinationPath.empty())
+    return Status(StatusCode::kBadRequest, "Destination path cannot be empty");
+
+  if (sourcePath == destinationPath) return Status();
+#ifdef _WIN32
+  if (!MoveFileA(sourcePath.c_str(), destinationPath.c_str())) {
+    DWORD error = GetLastError();
+    if (error == ERROR_FILE_NOT_FOUND)
+      return Status(StatusCode::kNotFound,
+                    "Source file not found: " + sourcePath);
+
+    if (error == ERROR_PATH_NOT_FOUND)
+      return Status(StatusCode::kNotFound,
+                    "Source or destination path not found");
+
+    if (error == ERROR_ALREADY_EXISTS)
+      return Status(StatusCode::kConflict,
+                    "Destination file already exists: " + destinationPath);
+
+    if (error == ERROR_ACCESS_DENIED)
+      return Status(StatusCode::kForbidden, "Access denied when moving file");
+
+    return Status(StatusCode::kInternalError,
+                  "Failed to move file: " + GetLastErrorMessage());
+  }
+#else
+  if (rename(sourcePath.c_str(), destinationPath.c_str()) != 0) {
+    if (errno == ENOENT)
+      return Status(StatusCode::kNotFound,
+                    "Source file not found: " + sourcePath);
+
+    if (errno == EEXIST)
+      return Status(StatusCode::kConflict,
+                    "Destination file already exists: " + destinationPath);
+
+    if (errno == EACCES || errno == EPERM)
+      return Status(StatusCode::kForbidden,
+                    "Permission denied when moving file");
+
+    if (errno == EXDEV)
+      return Status(StatusCode::kNotImplemented,
+                    "Cross-device move not supported. Source and destination "
+                    "must be on the same filesystem");
+
+    return Status(StatusCode::kInternalError,
+                  "Failed to move file: " + GetLastErrorMessage());
+  }
+#endif
+
+  return Status();
+}
+
+Status File::Delete(const std::string& path) {
+  if (path.empty())
+    return Status(StatusCode::kBadRequest, "Path cannot be empty");
+
+#ifdef _WIN32
+  if (!DeleteFileA(path.c_str())) {
+    DWORD error = GetLastError();
+    if (error == ERROR_FILE_NOT_FOUND)
+      return Status(StatusCode::kNotFound, "File not found: " + path);
+
+    if (error == ERROR_PATH_NOT_FOUND)
+      return Status(StatusCode::kNotFound, "Path not found: " + path);
+
+    if (error == ERROR_ACCESS_DENIED)
+      return Status(StatusCode::kForbidden,
+                    "Access denied when deleting file: " + path);
+
+    if (error == ERROR_SHARING_VIOLATION)
+      return Status(StatusCode::kConflict,
+                    "File is in use and cannot be deleted: " + path);
+
+    return Status(StatusCode::kInternalError,
+                  "Failed to delete file: " + GetLastErrorMessage());
+  }
+#else
+  if (unlink(path.c_str()) != 0) {
+    if (errno == ENOENT)
+      return Status(StatusCode::kNotFound, "File not found: " + path);
+
+    if (errno == EACCES || errno == EPERM)
+      return Status(StatusCode::kForbidden,
+                    "Permission denied when deleting file: " + path);
+
+    if (errno == EISDIR)
+      return Status(StatusCode::kBadRequest,
+                    "Path is a directory, not a file: " + path);
+
+    if (errno == EBUSY)
+      return Status(StatusCode::kConflict,
+                    "File is in use and cannot be deleted: " + path);
+
+    return Status(StatusCode::kInternalError,
+                  "Failed to delete file: " + GetLastErrorMessage());
+  }
+#endif
+
+  return Status();
+}
+
 StatusOr<std::string> File::ReadAllText(const std::string& path) {
   FileStream stream;
   ASSIGN_OR_RETURN(stream, Open(path, FileMode::kOpen, FileAccess::kRead));
@@ -39,6 +173,7 @@ StatusOr<std::string> File::ReadAllText(const std::string& path) {
   ASSIGN_OR_RETURN(bytes_read, stream.Read(buffer));
   if (bytes_read < length)
     return Status(StatusCode::kInternalError, "Failed to read the entire file");
+
   return std::string(reinterpret_cast<const char*>(buffer.begin()),
                      buffer.Length());
 }
@@ -61,7 +196,6 @@ StatusOr<Array<unsigned char>> File::ReadAllBytes(const std::string& path) {
   ASSIGN_OR_RETURN(length, stream.Read(buffer));
   return buffer;
 }
-
 }  // namespace io
 }  // namespace ws
 

--- a/src/ws/io/file.cc
+++ b/src/ws/io/file.cc
@@ -1,13 +1,5 @@
 #include "ws/io/file.h"
 
-#include <sstream>
-#include <vector>
-
-#include "ws/array.h"
-#include "ws/span.h"
-#include "ws/string/string_helpers.h"
-#include "ws/types.h"
-
 namespace ws {
 namespace io {
 
@@ -72,3 +64,5 @@ StatusOr<Array<unsigned char>> File::ReadAllBytes(const std::string& path) {
 
 }  // namespace io
 }  // namespace ws
+
+// FIXME: TEST LINUX IMPLEMENTATION

--- a/src/ws/io/file.cc
+++ b/src/ws/io/file.cc
@@ -193,7 +193,11 @@ StatusOr<Array<unsigned char>> File::ReadAllBytes(const std::string& path) {
   offset_t length = stream.Length();
   if (length == 0) return Array<unsigned char>(0);
   Array<unsigned char> buffer(length);
-  ASSIGN_OR_RETURN(length, stream.Read(buffer));
+  offset_t bytes_read;
+  ASSIGN_OR_RETURN(bytes_read, stream.Read(buffer));
+  if (bytes_read < length)
+    return Status(StatusCode::kInternalError, "Failed to read the entire file");
+
   return buffer;
 }
 }  // namespace io

--- a/src/ws/io/file.cc
+++ b/src/ws/io/file.cc
@@ -202,5 +202,3 @@ StatusOr<Array<unsigned char>> File::ReadAllBytes(const std::string& path) {
 }
 }  // namespace io
 }  // namespace ws
-
-// FIXME: TEST LINUX IMPLEMENTATION

--- a/src/ws/io/file.h
+++ b/src/ws/io/file.h
@@ -3,10 +3,15 @@
 #include <string>
 #include <vector>
 
+#include "ws/array.h"
 #include "ws/io/file_access.h"
 #include "ws/io/file_mode.h"
 #include "ws/io/file_share.h"
 #include "ws/io/file_stream.h"
+#include "ws/machine.h"
+#include "ws/span.h"
+#include "ws/string/string_helpers.h"
+#include "ws/types.h"
 
 namespace ws {
 namespace io {

--- a/src/ws/io/file.h
+++ b/src/ws/io/file.h
@@ -24,7 +24,10 @@ class File {
                                    FileAccess access);
   static StatusOr<FileStream> Open(const std::string& path, FileMode mode,
                                    FileAccess access, FileShare share);
-
+  static StatusOr<bool> Exists(const std::string& path);
+  static Status Move(const std::string& sourcePath,
+                     const std::string& destinationPath);
+  static Status Delete(const std::string& path);
   static StatusOr<std::string> ReadAllText(const std::string& path);
   static StatusOr<Array<std::string>> ReadAllLines(const std::string& path);
   static StatusOr<Array<unsigned char>> ReadAllBytes(const std::string& path);

--- a/src/ws/io/file_handle.cc
+++ b/src/ws/io/file_handle.cc
@@ -2,17 +2,6 @@
 
 namespace ws {
 namespace io {
-
-std::filesystem::path FileHandle::GetFullPath(const std::string& input) {
-  std::filesystem::path user_path(input);
-  return std::filesystem::absolute(user_path);
-}
-
-std::filesystem::path FileHandle::GetFullPath(const std::wstring& input) {
-  std::filesystem::path user_path(input);
-  return std::filesystem::absolute(user_path);
-}
-
 std::filesystem::path FileHandle::Path() const { return path_; }
 
 #ifdef _WIN32

--- a/src/ws/io/file_handle.cc
+++ b/src/ws/io/file_handle.cc
@@ -527,4 +527,3 @@ int ParseShareMode(FileShare /*share*/) { return 0; }
 #endif
 }  // namespace io
 }  // namespace ws
-// FIXME: TEST LINUX IMPLEMENTATION

--- a/src/ws/io/file_handle.cc
+++ b/src/ws/io/file_handle.cc
@@ -548,3 +548,4 @@ int ParseShareMode(FileShare /*share*/) { return 0; }
 #endif
 }  // namespace io
 }  // namespace ws
+// FIXME: TEST LINUX IMPLEMENTATION

--- a/src/ws/io/file_handle.cc
+++ b/src/ws/io/file_handle.cc
@@ -103,10 +103,7 @@ StatusOr<offset_t> FileHandle::ReadAtOffset(FileHandle& handle,
   if (error_code == ERROR_HANDLE_EOF)
     return static_cast<offset_t>(num_bytes_read);
 
-  bool is_end_of_file;
-  ASSIGN_OR_RETURN(is_end_of_file,
-                   IsEndOfFile(error_code, handle, file_offset));
-  if (!is_end_of_file)
+  if (!IsEndOfFile(error_code, handle, file_offset).ValueOr(false))
     return Status(StatusCode::kRuntimeError,
                   "IO Error: ReadFile failed: " + GetLastErrorMessage());
 
@@ -161,10 +158,7 @@ StatusOr<bool> FileHandle::IsEndOfFile(offset_t error_code, FileHandle& handle,
     case ERROR_PIPE_NOT_CONNECTED:
       return true;
     case ERROR_INVALID_PARAMETER:
-      bool is_end_of_file;
-      ASSIGN_OR_RETURN(is_end_of_file,
-                       IsEndOfFileForNoBuffering(handle, file_offset));
-      return is_end_of_file;
+      return IsEndOfFileForNoBuffering(handle, file_offset).ValueOr(false);
     default:
       break;
   }

--- a/src/ws/io/file_handle.h
+++ b/src/ws/io/file_handle.h
@@ -38,8 +38,6 @@ class FileHandle {
                               offset_t file_offset);
   static StatusOr<bool> IsEndOfFile(offset_t error_code, FileHandle& handle,
                                     offset_t file_offset);
-  static std::filesystem::path GetFullPath(const std::string& input);
-  static std::filesystem::path GetFullPath(const std::wstring& input);
 
   std::filesystem::path Path() const;
   bool IsClosed() const;

--- a/src/ws/io/file_stream.cc
+++ b/src/ws/io/file_stream.cc
@@ -18,7 +18,7 @@ StatusOr<FileStream> FileStream::Create(const std::string& path, FileMode mode,
                                         FileAccess access, FileShare share,
                                         offset_t buffer_size,
                                         offset_t preallocation_size) {
-  std::filesystem::path full_path = std::filesystem::absolute(path);
+  std::filesystem::path full_path = Path::GetFullPath(path);
   offset_t position = 0;
   offset_t append_start = -1;
   FileHandle file_handle;

--- a/src/ws/io/file_stream.h
+++ b/src/ws/io/file_stream.h
@@ -10,6 +10,7 @@
 #include "ws/io/file_access.h"
 #include "ws/io/file_handle.h"
 #include "ws/io/file_mode.h"
+#include "ws/io/path.h"
 #include "ws/io/stream.h"
 #include "ws/status/status_or.h"
 

--- a/src/ws/io/memory_stream.cc
+++ b/src/ws/io/memory_stream.cc
@@ -287,7 +287,6 @@ Status MemoryStream::EnsureWriteable() const {
 }
 
 StatusOr<bool> MemoryStream::EnsureCapacity(offset_t value) {
-  static constexpr const offset_t k256 = 256;
   if (value > capacity_) {
     offset_t default_new_capacity = capacity_ * 2;
     offset_t new_capacity = std::max(value, k256);

--- a/src/ws/io/memory_stream.h
+++ b/src/ws/io/memory_stream.h
@@ -58,6 +58,8 @@ class MemoryStream : public Stream {
   StatusOr<bool> EnsureCapacity(offset_t value);
   offset_t Skip(offset_t count);
 
+  static constexpr const offset_t k256 = 256;
+
   Array<unsigned char> buffer_;
   offset_t position_;
   offset_t length_;

--- a/src/ws/io/path.cc
+++ b/src/ws/io/path.cc
@@ -3,6 +3,16 @@
 namespace ws {
 namespace io {
 
+std::filesystem::path Path::GetFullPath(const std::string& input) {
+  std::filesystem::path user_path(input);
+  return std::filesystem::absolute(user_path);
+}
+
+std::filesystem::path Path::GetFullPath(const std::wstring& input) {
+  std::filesystem::path user_path(input);
+  return std::filesystem::absolute(user_path);
+}
+
 StatusOr<bool> Path::IsFile(const std::string& path) {
 #ifdef _WIN32
   DWORD attrs = GetFileAttributesA(path.c_str());

--- a/src/ws/io/path.cc
+++ b/src/ws/io/path.cc
@@ -3,16 +3,6 @@
 namespace ws {
 namespace io {
 
-std::filesystem::path Path::GetFullPath(const std::string& input) {
-  std::filesystem::path user_path(input);
-  return std::filesystem::absolute(user_path);
-}
-
-std::filesystem::path Path::GetFullPath(const std::wstring& input) {
-  std::filesystem::path user_path(input);
-  return std::filesystem::absolute(user_path);
-}
-
 StatusOr<bool> Path::IsFile(const std::string& path) {
 #ifdef _WIN32
   DWORD attrs = GetFileAttributesA(path.c_str());
@@ -163,6 +153,25 @@ StatusOr<std::string> Path::GetParent(const std::string& path) {
   if (lastSeparator == 0) return std::string("/");
   return normalizedPath.substr(0, lastSeparator);
 #endif
+}
+
+StatusOr<std::string> Path::GetExtension(const std::string& path) {
+  if (path.empty())
+    return Status(StatusCode::kBadRequest, "Path cannot be empty");
+
+  std::filesystem::path fs_path(path);
+  std::string extension = fs_path.extension().string();
+  return extension;
+}
+
+std::filesystem::path Path::GetFullPath(const std::string& input) {
+  std::filesystem::path user_path(input);
+  return std::filesystem::absolute(user_path);
+}
+
+std::filesystem::path Path::GetFullPath(const std::wstring& input) {
+  std::filesystem::path user_path(input);
+  return std::filesystem::absolute(user_path);
 }
 }  // namespace io
 }  // namespace ws

--- a/src/ws/io/path.cc
+++ b/src/ws/io/path.cc
@@ -166,5 +166,3 @@ StatusOr<std::string> Path::GetParent(const std::string& path) {
 }
 }  // namespace io
 }  // namespace ws
-
-// FIXME: TEST LINUX IMPLEMENTATION

--- a/src/ws/io/path.cc
+++ b/src/ws/io/path.cc
@@ -8,24 +8,22 @@ StatusOr<bool> Path::IsFile(const std::string& path) {
   DWORD attrs = GetFileAttributesA(path.c_str());
   if (attrs == INVALID_FILE_ATTRIBUTES) {
     DWORD error = GetLastError();
-    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND)
       return false;
-    }
+
     return Status(StatusCode::kInternalError,
                   "Failed to check file existence: " + GetLastErrorMessage());
   }
-  // Return true if it's NOT a directory (i.e., it's a regular file)
+
   return (attrs & FILE_ATTRIBUTE_DIRECTORY) == 0;
 #else
   struct stat statbuf;
   if (stat(path.c_str(), &statbuf) != 0) {
-    if (errno == ENOENT) {
-      return false;
-    }
+    if (errno == ENOENT) return false;
     return Status(StatusCode::kInternalError,
                   "Failed to check file existence: " + GetLastErrorMessage());
   }
-  // Return true if it's a regular file
+
   return S_ISREG(statbuf.st_mode);
 #endif
 }
@@ -35,31 +33,26 @@ StatusOr<bool> Path::IsDirectory(const std::string& path) {
   DWORD attrs = GetFileAttributesA(path.c_str());
   if (attrs == INVALID_FILE_ATTRIBUTES) {
     DWORD error = GetLastError();
-    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND)
       return false;
-    }
+
     return Status(
         StatusCode::kInternalError,
         "Failed to check directory existence: " + GetLastErrorMessage());
   }
+
   return (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0;
 #else
   struct stat statbuf;
   if (stat(path.c_str(), &statbuf) != 0) {
-    if (errno == ENOENT) {
-      return false;
-    }
+    if (errno == ENOENT) return false;
     return Status(
         StatusCode::kInternalError,
         "Failed to check directory existence: " + GetLastErrorMessage());
   }
+
   return S_ISDIR(statbuf.st_mode);
 #endif
-}
-
-StatusOr<bool> Path::IsRegularFile(const std::string& path) {
-  // Alias for IsFile for clarity
-  return IsFile(path);
 }
 
 StatusOr<bool> Path::IsSpecialFile(const std::string& path) {
@@ -67,26 +60,22 @@ StatusOr<bool> Path::IsSpecialFile(const std::string& path) {
   DWORD attrs = GetFileAttributesA(path.c_str());
   if (attrs == INVALID_FILE_ATTRIBUTES) {
     DWORD error = GetLastError();
-    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND)
       return false;
-    }
+
     return Status(StatusCode::kInternalError,
                   "Failed to check file type: " + GetLastErrorMessage());
   }
 
-  // In Windows, check for system/hidden files or special attributes
   return (attrs & (FILE_ATTRIBUTE_SYSTEM | FILE_ATTRIBUTE_DEVICE)) != 0;
 #else
   struct stat statbuf;
   if (stat(path.c_str(), &statbuf) != 0) {
-    if (errno == ENOENT) {
-      return false;
-    }
+    if (errno == ENOENT) return false;
     return Status(StatusCode::kInternalError,
                   "Failed to check file type: " + GetLastErrorMessage());
   }
 
-  // Return true if it's any special file type (not regular file or directory)
   return S_ISCHR(statbuf.st_mode) ||   // Character device
          S_ISBLK(statbuf.st_mode) ||   // Block device
          S_ISFIFO(statbuf.st_mode) ||  // Named pipe/FIFO
@@ -99,26 +88,22 @@ StatusOr<bool> Path::IsSymbolicLink(const std::string& path) {
   DWORD attrs = GetFileAttributesA(path.c_str());
   if (attrs == INVALID_FILE_ATTRIBUTES) {
     DWORD error = GetLastError();
-    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND)
       return false;
-    }
+
     return Status(StatusCode::kInternalError,
                   "Failed to check link type: " + GetLastErrorMessage());
   }
 
-  // Check for reparse point (Windows equivalent of symbolic links)
   return (attrs & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
 #else
   struct stat statbuf;
-  if (lstat(path.c_str(), &statbuf) != 0) {  // Use lstat to not follow symlinks
-    if (errno == ENOENT) {
-      return false;
-    }
+  if (lstat(path.c_str(), &statbuf) != 0) {
+    if (errno == ENOENT) return false;
     return Status(StatusCode::kInternalError,
                   "Failed to check link type: " + GetLastErrorMessage());
   }
 
-  // Return true if it's a symbolic link
   return S_ISLNK(statbuf.st_mode);
 #endif
 }
@@ -137,67 +122,38 @@ std::string Path::NormalizePath(const std::string& path) {
 }
 
 StatusOr<std::string> Path::GetParent(const std::string& path) {
-  if (path.empty()) {
+  if (path.empty())
     return Status(StatusCode::kBadRequest, "Path cannot be empty");
-  }
 
-  // Remove trailing separators to normalize the path
   std::string normalizedPath = path;
   while (!normalizedPath.empty() &&
          (normalizedPath.back() == '/' || normalizedPath.back() == '\\')) {
     normalizedPath.pop_back();
   }
 
-  if (normalizedPath.empty()) {
+  if (normalizedPath.empty())
     return Status(StatusCode::kBadRequest,
                   "Invalid path: root path has no parent");
-  }
 
 #ifdef _WIN32
-  // Handle Windows drive letters (e.g., "C:" has no parent)
-  if (normalizedPath.length() == 2 && normalizedPath[1] == ':') {
+  if (normalizedPath.length() == 2 && normalizedPath[1] == ':')
     return Status(StatusCode::kBadRequest,
                   "Drive root has no parent: " + normalizedPath);
-  }
 
-  // Find the last backslash or forward slash
   size_t lastSeparator = normalizedPath.find_last_of("\\/");
-
-  if (lastSeparator == std::string::npos) {
-    // No separator found - return current directory
-    return std::string(".");
-  }
-
-  if (lastSeparator == 0) {
-    // Root directory case
-    return std::string("\\");
-  }
-
-  // Handle drive letter case (e.g., "C:\folder" -> "C:\")
-  if (lastSeparator == 2 && normalizedPath[1] == ':') {
+  if (lastSeparator == std::string::npos) return std::string(".");
+  if (lastSeparator == 0) return std::string("\\");
+  if (lastSeparator == 2 && normalizedPath[1] == ':')
     return normalizedPath.substr(0, lastSeparator + 1);
-  }
 
   return normalizedPath.substr(0, lastSeparator);
-
 #else
-  // Unix-like systems
   size_t lastSeparator = normalizedPath.find_last_of('/');
-
-  if (lastSeparator == std::string::npos) {
-    // No separator found - return current directory
-    return std::string(".");
-  }
-
-  if (lastSeparator == 0) {
-    // Root directory case
-    return std::string("/");
-  }
-
+  if (lastSeparator == std::string::npos) return std::string(".");
+  if (lastSeparator == 0) return std::string("/");
   return normalizedPath.substr(0, lastSeparator);
 #endif
 }
-
 }  // namespace io
 }  // namespace ws
 

--- a/src/ws/io/path.cc
+++ b/src/ws/io/path.cc
@@ -1,0 +1,204 @@
+#include "ws/io/path.h"
+
+namespace ws {
+namespace io {
+
+StatusOr<bool> Path::IsFile(const std::string& path) {
+#ifdef _WIN32
+  DWORD attrs = GetFileAttributesA(path.c_str());
+  if (attrs == INVALID_FILE_ATTRIBUTES) {
+    DWORD error = GetLastError();
+    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+      return false;
+    }
+    return Status(StatusCode::kInternalError,
+                  "Failed to check file existence: " + GetLastErrorMessage());
+  }
+  // Return true if it's NOT a directory (i.e., it's a regular file)
+  return (attrs & FILE_ATTRIBUTE_DIRECTORY) == 0;
+#else
+  struct stat statbuf;
+  if (stat(path.c_str(), &statbuf) != 0) {
+    if (errno == ENOENT) {
+      return false;
+    }
+    return Status(StatusCode::kInternalError,
+                  "Failed to check file existence: " + GetLastErrorMessage());
+  }
+  // Return true if it's a regular file
+  return S_ISREG(statbuf.st_mode);
+#endif
+}
+
+StatusOr<bool> Path::IsDirectory(const std::string& path) {
+#ifdef _WIN32
+  DWORD attrs = GetFileAttributesA(path.c_str());
+  if (attrs == INVALID_FILE_ATTRIBUTES) {
+    DWORD error = GetLastError();
+    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+      return false;
+    }
+    return Status(
+        StatusCode::kInternalError,
+        "Failed to check directory existence: " + GetLastErrorMessage());
+  }
+  return (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0;
+#else
+  struct stat statbuf;
+  if (stat(path.c_str(), &statbuf) != 0) {
+    if (errno == ENOENT) {
+      return false;
+    }
+    return Status(
+        StatusCode::kInternalError,
+        "Failed to check directory existence: " + GetLastErrorMessage());
+  }
+  return S_ISDIR(statbuf.st_mode);
+#endif
+}
+
+StatusOr<bool> Path::IsRegularFile(const std::string& path) {
+  // Alias for IsFile for clarity
+  return IsFile(path);
+}
+
+StatusOr<bool> Path::IsSpecialFile(const std::string& path) {
+#ifdef _WIN32
+  DWORD attrs = GetFileAttributesA(path.c_str());
+  if (attrs == INVALID_FILE_ATTRIBUTES) {
+    DWORD error = GetLastError();
+    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+      return false;
+    }
+    return Status(StatusCode::kInternalError,
+                  "Failed to check file type: " + GetLastErrorMessage());
+  }
+
+  // In Windows, check for system/hidden files or special attributes
+  return (attrs & (FILE_ATTRIBUTE_SYSTEM | FILE_ATTRIBUTE_DEVICE)) != 0;
+#else
+  struct stat statbuf;
+  if (stat(path.c_str(), &statbuf) != 0) {
+    if (errno == ENOENT) {
+      return false;
+    }
+    return Status(StatusCode::kInternalError,
+                  "Failed to check file type: " + GetLastErrorMessage());
+  }
+
+  // Return true if it's any special file type (not regular file or directory)
+  return S_ISCHR(statbuf.st_mode) ||   // Character device
+         S_ISBLK(statbuf.st_mode) ||   // Block device
+         S_ISFIFO(statbuf.st_mode) ||  // Named pipe/FIFO
+         S_ISSOCK(statbuf.st_mode);    // Socket
+#endif
+}
+
+StatusOr<bool> Path::IsSymbolicLink(const std::string& path) {
+#ifdef _WIN32
+  DWORD attrs = GetFileAttributesA(path.c_str());
+  if (attrs == INVALID_FILE_ATTRIBUTES) {
+    DWORD error = GetLastError();
+    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+      return false;
+    }
+    return Status(StatusCode::kInternalError,
+                  "Failed to check link type: " + GetLastErrorMessage());
+  }
+
+  // Check for reparse point (Windows equivalent of symbolic links)
+  return (attrs & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
+#else
+  struct stat statbuf;
+  if (lstat(path.c_str(), &statbuf) != 0) {  // Use lstat to not follow symlinks
+    if (errno == ENOENT) {
+      return false;
+    }
+    return Status(StatusCode::kInternalError,
+                  "Failed to check link type: " + GetLastErrorMessage());
+  }
+
+  // Return true if it's a symbolic link
+  return S_ISLNK(statbuf.st_mode);
+#endif
+}
+
+std::string Path::NormalizePath(const std::string& path) {
+  std::string normalized = path;
+  if (!normalized.empty() && normalized.back() != '/' &&
+      normalized.back() != '\\') {
+#ifdef _WIN32
+    normalized += "\\";
+#else
+    normalized += "/";
+#endif
+  }
+  return normalized;
+}
+
+StatusOr<std::string> Path::GetParent(const std::string& path) {
+  if (path.empty()) {
+    return Status(StatusCode::kBadRequest, "Path cannot be empty");
+  }
+
+  // Remove trailing separators to normalize the path
+  std::string normalizedPath = path;
+  while (!normalizedPath.empty() &&
+         (normalizedPath.back() == '/' || normalizedPath.back() == '\\')) {
+    normalizedPath.pop_back();
+  }
+
+  if (normalizedPath.empty()) {
+    return Status(StatusCode::kBadRequest,
+                  "Invalid path: root path has no parent");
+  }
+
+#ifdef _WIN32
+  // Handle Windows drive letters (e.g., "C:" has no parent)
+  if (normalizedPath.length() == 2 && normalizedPath[1] == ':') {
+    return Status(StatusCode::kBadRequest,
+                  "Drive root has no parent: " + normalizedPath);
+  }
+
+  // Find the last backslash or forward slash
+  size_t lastSeparator = normalizedPath.find_last_of("\\/");
+
+  if (lastSeparator == std::string::npos) {
+    // No separator found - return current directory
+    return std::string(".");
+  }
+
+  if (lastSeparator == 0) {
+    // Root directory case
+    return std::string("\\");
+  }
+
+  // Handle drive letter case (e.g., "C:\folder" -> "C:\")
+  if (lastSeparator == 2 && normalizedPath[1] == ':') {
+    return normalizedPath.substr(0, lastSeparator + 1);
+  }
+
+  return normalizedPath.substr(0, lastSeparator);
+
+#else
+  // Unix-like systems
+  size_t lastSeparator = normalizedPath.find_last_of('/');
+
+  if (lastSeparator == std::string::npos) {
+    // No separator found - return current directory
+    return std::string(".");
+  }
+
+  if (lastSeparator == 0) {
+    // Root directory case
+    return std::string("/");
+  }
+
+  return normalizedPath.substr(0, lastSeparator);
+#endif
+}
+
+}  // namespace io
+}  // namespace ws
+
+// FIXME: TEST LINUX IMPLEMENTATION

--- a/src/ws/io/path.h
+++ b/src/ws/io/path.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+
+#include "ws/machine.h"
+#include "ws/status/status_or.h"
+
+namespace ws {
+namespace io {
+
+class Path {
+ public:
+  static StatusOr<bool> IsFile(const std::string& path);
+  static StatusOr<bool> IsDirectory(const std::string& path);
+  static StatusOr<bool> IsRegularFile(const std::string& path);
+  static StatusOr<bool> IsSpecialFile(const std::string& path);
+  static StatusOr<bool> IsSymbolicLink(const std::string& path);
+  static std::string NormalizePath(const std::string& path);
+  static StatusOr<std::string> GetParent(const std::string& path);
+
+ private:
+  static constexpr int kDefaultPermissions = 0755;
+};
+
+}  // namespace io
+}  // namespace ws

--- a/src/ws/io/path.h
+++ b/src/ws/io/path.h
@@ -12,7 +12,6 @@ class Path {
  public:
   static StatusOr<bool> IsFile(const std::string& path);
   static StatusOr<bool> IsDirectory(const std::string& path);
-  static StatusOr<bool> IsRegularFile(const std::string& path);
   static StatusOr<bool> IsSpecialFile(const std::string& path);
   static StatusOr<bool> IsSymbolicLink(const std::string& path);
   static std::string NormalizePath(const std::string& path);

--- a/src/ws/io/path.h
+++ b/src/ws/io/path.h
@@ -17,6 +17,7 @@ class Path {
   static StatusOr<bool> IsSymbolicLink(const std::string& path);
   static std::string NormalizePath(const std::string& path);
   static StatusOr<std::string> GetParent(const std::string& path);
+  static StatusOr<std::string> GetExtension(const std::string& path);
   static std::filesystem::path GetFullPath(const std::string& input);
   static std::filesystem::path GetFullPath(const std::wstring& input);
 

--- a/src/ws/io/path.h
+++ b/src/ws/io/path.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <string>
 
 #include "ws/machine.h"
@@ -16,6 +17,8 @@ class Path {
   static StatusOr<bool> IsSymbolicLink(const std::string& path);
   static std::string NormalizePath(const std::string& path);
   static StatusOr<std::string> GetParent(const std::string& path);
+  static std::filesystem::path GetFullPath(const std::string& input);
+  static std::filesystem::path GetFullPath(const std::wstring& input);
 
  private:
   static constexpr int kDefaultPermissions = 0755;

--- a/src/ws/logging/events/log_event.h
+++ b/src/ws/logging/events/log_event.h
@@ -18,7 +18,7 @@ class LogEvent {
            const map_type& properties = map_type());
 
   std::string SourceContext() const;
-  LogLevel Level() const;
+  constexpr LogLevel Level() const;
   std::string Message() const;
   std::chrono::system_clock::time_point Timestamp() const;
   std::optional<mapped_type> GetProperty(const key_type& key) const;
@@ -38,7 +38,7 @@ class LogEvent {
 
 inline std::string LogEvent::SourceContext() const { return source_context_; }
 
-inline LogLevel LogEvent::Level() const { return level_; }
+inline constexpr LogLevel LogEvent::Level() const { return level_; }
 
 inline std::string LogEvent::Message() const { return message_; }
 

--- a/src/ws/logging/rendering/message_renderer.cc
+++ b/src/ws/logging/rendering/message_renderer.cc
@@ -1,6 +1,5 @@
 #include "ws/logging/rendering/message_renderer.h"
 
-#include <stdexcept>
 namespace ws {
 namespace logging {
 MessageRenderer::MessageRenderer(const std::string& template_format) {

--- a/src/ws/logging/rendering/message_renderer.h
+++ b/src/ws/logging/rendering/message_renderer.h
@@ -4,6 +4,7 @@
 #include <iomanip>
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/src/ws/machine.h
+++ b/src/ws/machine.h
@@ -38,6 +38,7 @@
 #endif
 
 #include <cassert>
+#include <cstring>
 #include <mutex>
 #include <thread>
 

--- a/src/ws/machine.h
+++ b/src/ws/machine.h
@@ -21,6 +21,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #ifdef __APPLE__
+#include <sys/fcntl.h>
 #include <sys/mount.h>
 #include <sys/param.h>
 #else

--- a/src/ws/machine.h
+++ b/src/ws/machine.h
@@ -6,17 +6,26 @@
 #define KEEP_WIN_ORDER
 #include <winsock2.h>
 #undef KEEP_WIN_ORDER
+#include <shlwapi.h>
 #include <windows.h>
 #else
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
 #if defined(__linux__) && !defined(__GLIBC__)
 #include <bits/alltypes.h>
 #endif
-#include <fcntl.h>
-#include <unistd.h>
 #define KEEP_LINUX_ORDER
 #include <sys/types.h>
 #undef KEEP_LINUX_ORDER
 #include <sys/stat.h>
+#include <unistd.h>
+#ifdef __APPLE__
+#include <sys/mount.h>
+#include <sys/param.h>
+#else
+#include <sys/statfs.h>
+#endif
 #endif
 
 #include <cstdint>
@@ -222,6 +231,25 @@ T CpuReverseBits(T src) {
 
 static std::mutex console_mutex;
 }  // namespace internal
+
+inline std::string GetLastErrorMessage() {
+#ifdef _WIN32
+  DWORD error = GetLastError();
+  if (error == 0) return "No error";
+  LPSTR messageBuffer = nullptr;
+  size_t size = FormatMessageA(
+      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+          FORMAT_MESSAGE_IGNORE_INSERTS,
+      nullptr, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+      reinterpret_cast<LPSTR>(&messageBuffer), 0, nullptr);
+
+  std::string message(messageBuffer, size);
+  LocalFree(messageBuffer);
+  return message;
+#else
+  return std::string(strerror(errno));
+#endif
+}
 
 inline void FormatConsoleOutput() {
 #ifdef _WIN32

--- a/src/ws/status/status.h
+++ b/src/ws/status/status.h
@@ -17,8 +17,8 @@ class Status {
 
   ~Status() = default;
 
-  bool Ok() const;
-  StatusCode Code() const;
+  constexpr bool Ok() const;
+  constexpr StatusCode Code() const;
   const std::string& Message() const;
   std::string ToString() const;
 
@@ -45,9 +45,9 @@ inline Status::Status(const Status& status)
 inline ws::Status::Status(Status&& other) noexcept
     : code_(other.code_), message_(std::move(other.message_)) {}
 
-inline bool Status::Ok() const { return code_ == StatusCode::kOk; }
+inline constexpr bool Status::Ok() const { return code_ == StatusCode::kOk; }
 
-inline StatusCode Status::Code() const { return code_; }
+inline constexpr StatusCode Status::Code() const { return code_; }
 
 inline const std::string& Status::Message() const { return message_; }
 

--- a/src/ws/status/status_or.h
+++ b/src/ws/status/status_or.h
@@ -35,6 +35,10 @@ class StatusOr {
   T& Value() &;
   const T&& Value() const&&;
   T&& Value() &&;
+  template <typename U = T>
+  T ValueOr(U&& default_value) const&;
+  template <typename U = T>
+  T ValueOr(U&& default_value) &&;
 
   template <typename U>
   friend inline bool operator==(const StatusOr<U>&, const StatusOr<U>&);
@@ -117,6 +121,24 @@ template <typename T>
 inline T&& StatusOr<T>::Value() && {
   EnsureValue();
   return std::move(*value_);
+}
+
+template <typename T>
+template <typename U>
+inline T StatusOr<T>::ValueOr(U&& default_value) const& {
+  if (Ok() && value_.has_value()) {
+    return *value_;
+  }
+  return static_cast<T>(std::forward<U>(default_value));
+}
+
+template <typename T>
+template <typename U>
+inline T StatusOr<T>::ValueOr(U&& default_value) && {
+  if (Ok() && value_.has_value()) {
+    return std::move(*value_);
+  }
+  return static_cast<T>(std::forward<U>(default_value));
 }
 
 template <typename T>

--- a/src/ws/status/status_or.h
+++ b/src/ws/status/status_or.h
@@ -29,7 +29,7 @@ class StatusOr {
 
   ~StatusOr() = default;
 
-  bool Ok() const;
+  constexpr bool Ok() const;
   const Status& GetStatus() const;
   const T& Value() const&;
   T& Value() &;
@@ -90,7 +90,7 @@ inline StatusOr<T>& StatusOr<T>::operator=(StatusOr&& other) noexcept {
 }
 
 template <typename T>
-inline bool StatusOr<T>::Ok() const {
+inline constexpr bool StatusOr<T>::Ok() const {
   return status_.Ok();
 }
 
@@ -126,18 +126,14 @@ inline T&& StatusOr<T>::Value() && {
 template <typename T>
 template <typename U>
 inline T StatusOr<T>::ValueOr(U&& default_value) const& {
-  if (Ok() && value_.has_value()) {
-    return *value_;
-  }
+  if (Ok() && value_.has_value()) return *value_;
   return static_cast<T>(std::forward<U>(default_value));
 }
 
 template <typename T>
 template <typename U>
 inline T StatusOr<T>::ValueOr(U&& default_value) && {
-  if (Ok() && value_.has_value()) {
-    return std::move(*value_);
-  }
+  if (Ok() && value_.has_value()) return std::move(*value_);
   return static_cast<T>(std::forward<U>(default_value));
 }
 


### PR DESCRIPTION
This pull request introduces several changes across multiple files, primarily focusing on improvements to code efficiency, readability, and functionality. The changes include the addition of `constexpr` qualifiers to enhance compile-time evaluation, new functionality for color encoding conversions, and updates to build configurations. Below is a categorized summary of the most important changes.

### Code optimization and efficiency:
* Added `constexpr` qualifiers to methods in `src/ws/imaging/image.h`, `src/ws/imaging/image_component.h`, `src/ws/imaging/image_converter.h`, and `src/ws/imaging/pixel/pixel_format_details.h` to enable compile-time evaluation for better performance. [[1]](diffhunk://#diff-7cb41f3c5ff8eae2c2f54bf3833811b1bb669190e3bc808a98726273cb75e53eL36-R39) [[2]](diffhunk://#diff-af8e20d8d0a171fd2f3524e4ac2bb4f58257a1bf7eb0fbd63e485b5a814121b7L35-R43) [[3]](diffhunk://#diff-fe62ba3c77ab047f03bf6f1c2d39594b442d70abe96ceaefbb30694fe592af24L21-R23) [[4]](diffhunk://#diff-916eb92549851594eb317a3f19646085115684f7d87e332826b549551dd306c0L23-R32)

### Functionality enhancements:
* Introduced an enum `DigitalTvStudioEncodingRec` in `src/ws/imaging/pixel/pixel_color_converter.h` to support multiple encoding standards (e.g., BT.601, BT.709, BT.2020, BT.2100), and added a `GetEncodingCoefficients` method for retrieving encoding coefficients. [[1]](diffhunk://#diff-920c4b249055300cbb3d34c0dad88789b2e26c1dbfed0a2eb350a00ea573bf39R22-R27) [[2]](diffhunk://#diff-920c4b249055300cbb3d34c0dad88789b2e26c1dbfed0a2eb350a00ea573bf39R42-R58)
* Updated constructors for `SRgbToGrayConverter`, `SRgbToSYccConverter`, and `SYccToRgbConverter` classes to accept an encoding standard parameter, enabling flexible color format conversions. [[1]](diffhunk://#diff-fb9eb4c756a9926014288b9deea27089f7d4cce1ec453e9f55d234a1b830fe05L6-R9) [[2]](diffhunk://#diff-23ffdfeea76a1199be6f951cd2e763e149efaf621d21bc0b8107225209a7b715L12-R15) [[3]](diffhunk://#diff-d303d45be82b238d2dd23c65f26a1f443b84736aa6b7edfdc2bc9d080de04835L6-R9) [[4]](diffhunk://#diff-6c3abf34ae5508c849f0c02efa79fcd89ca05f0320c832d6503a809a50b39285L12-R15) [[5]](diffhunk://#diff-ddc794f66353370074b33af405fbbb9f5d86b43a3ab6d15e7f98cc5747e56565L6-R9) [[6]](diffhunk://#diff-f728ce34c1572f2cecaea2719e11f4adae6f1f693c351908518aef53e38bb876L12-R15)

### Removal of redundant code:
* Removed the `DetermineImageBufferType` function from `src/ws/imaging/image_buffer_type.cc` and replaced it with a `constexpr` implementation in `src/ws/imaging/image_buffer_type.h`. [[1]](diffhunk://#diff-cf58b93f9eb5d5d41dfe2ac42ba1d445a740efbb24377158f0572ca4eb8a1746L5-L19) [[2]](diffhunk://#diff-8a77cb65874645189bf4973458ee0d73a6152b256f2c9248cc14fd5d804582ffL18-R32)

### Build configuration updates:
* Updated `CMakeLists.txt` in `src/ws/io` to include new source files (`directory.cc`, `path.cc`) and corresponding headers (`directory.h`, `path.h`). [[1]](diffhunk://#diff-6df176a1c3deb6ec09d9286be4a95fa2f7d446ccb22db58217af77f0e9e51c85R6-R15) [[2]](diffhunk://#diff-6df176a1c3deb6ec09d9286be4a95fa2f7d446ccb22db58217af77f0e9e51c85R25)

### Documentation and licensing:
* Corrected copyright notices in `THIRD-PARTY-NOTICES` to reflect proper attribution and date ranges. [[1]](diffhunk://#diff-595b2bdbd64d2d54de80373af87ce7d7eff7045cf7a921f16ef9d056479accccL10-R10) [[2]](diffhunk://#diff-595b2bdbd64d2d54de80373af87ce7d7eff7045cf7a921f16ef9d056479accccL219-R219)

These changes collectively improve the codebase's maintainability, performance, and functionality while ensuring proper attribution in licensing documentation.